### PR TITLE
fix: Cannot get twitter open graph tags

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -27,6 +27,7 @@ class _MyHomePageState extends State<MyHomePage> {
   TextEditingController _controller;
   int _index = -1;
   final List<String> _urls = [
+    "https://twitter.com/sspai_com/status/1392794070704066566?s=20",
     "https://mp.weixin.qq.com/s/qj7gkU-Pbdcdn3zO6ZQxqg",
     "https://mp.weixin.qq.com/s/43GznPLxi5i3yOdvrlr1JQ",
     "https://m.tb.cn/h.VFcZsnK?sm=34cd13",

--- a/lib/web_analyzer.dart
+++ b/lib/web_analyzer.dart
@@ -181,14 +181,19 @@ class WebAnalyzer {
     final uri = Uri.parse(url);
     final ioClient = HttpClient()..badCertificateCallback = _certificateCheck;
     final client = IOClient(ioClient);
+    /*
+    Twitter website doesn't have open graph tags?
+    https://stackoverflow.com/a/64332370/5588637
+    */
     final request = Request('GET', uri)
       ..followRedirects = false
       ..headers["User-Agent"] = useDesktopAgent
-          ? "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36"
-          : "Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1"
+          ? "facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php) Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36"
+          : "facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php) Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1"
       ..headers["cache-control"] = "no-cache"
       ..headers["Cookie"] = cookie ?? _cookies[uri.host]
       ..headers["accept"] = "*/*";
+
     // print(request.headers);
     final stream = await client.send(request);
 


### PR DESCRIPTION
fix: https://github.com/yungzhu/flutter_link_preview/issues/12

>ref: 
>Bypassing the User-Agent whitelist to receive server-side-rendered (SSR) HTML
>https://stackoverflow.com/a/64332370/5588637